### PR TITLE
buildx for arm64 and fix ssl cert permissions

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -22,9 +22,11 @@ function build() {
     local type="${1}"
     local version="${2}"
 
-    docker build --no-cache -f "./docker/php-${version}/${type}.Dockerfile" -t "wsu-php-${version}-${type}" .
-    docker tag "wsu-php-${version}-${type}" "waynestate/php-${type}:${version}"
-    docker push "waynestate/php-${type}:${version}"
+    docker buildx build -f "./docker/php-${version}/${type}.Dockerfile" \
+        --platform "linux/amd64,linux/arm64" \
+        --push \
+        --tag "waynestate/php-${type}:${version}" \
+        .
 }
 
 if [[ "${argType}" == "all" && "${argPHPVersion}" == "all" ]]; then

--- a/gen-certs.sh
+++ b/gen-certs.sh
@@ -13,6 +13,6 @@ cd ..
 
 echo "+) Fixing permissions"
 # OSX uses staff instead of root as the group. Let's find it regardless of system.
-sudo find .certs/*/ -type f -name '*.pem' -exec chown root:${GROUPS} {} \;
+sudo find .certs/*/ -type f -name '*.pem' -exec chown ${UID}:${GROUPS} {} \;
 
 echo '+) Done!'


### PR DESCRIPTION
This includes both building for amd64 and arm64

Fix SSL permissions to go off ${UID} rather than root, otherwise it will cause errors because it's too low of permissions on MacOS